### PR TITLE
Filters files to unpack in the install script.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -10,7 +10,7 @@ echo "Creating bin directory"
 mkdir -p $install_path
 
 echo "Unpacking tar Archive"
-tar -xzvf $(get_download_path) 
+tar -xzvf $(get_download_path) kyverno
 
 echo "Installing kyverno-cli to ${install_path}"
 mv kyverno ${install_path}


### PR DESCRIPTION
Currently, the `asdf install kyverno` command leaves the `LICENSE` file in the current directory. This change adds a filter for the `tar` unpacking command, which will now only extract the `kyverno` binary.